### PR TITLE
Fix build issue for Windows systems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ apply plugin: 'eu.appsatori.fatjar'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 version = '0.0.1'
 jar {
     manifest {
@@ -31,6 +33,8 @@ repositories {
     mavenCentral()
     mavenLocal()
 }
+
+def androidSdkHome = "${System.getenv('ANDROID_HOME')}"
 
 dependencies {
     compile fileTree(dir: androidSdkHome + '/platforms/' + androidSdkTarget, include: '*.jar'), {
@@ -84,7 +88,8 @@ fatJar {
 task dex(dependsOn: fatJar, type:Exec) {
     project.dexDir.mkdirs()
     workingDir '.'
-    commandLine androidSdkHome + '/' + androidSdkBuildToolsDir + '/' + 'dx', '--dex', '--no-strict', '--output=' + project.dexedJar, jar.archivePath
+    def dx = 'dx' + (Os.isFamily(Os.FAMILY_WINDOWS) ? '.bat' : '')
+    commandLine androidSdkHome + '/' + androidSdkBuildToolsDir + '/' + dx, '--dex', '--no-strict', '--output=' + project.dexedJar, jar.archivePath
 }
 
 publishToMavenLocal.dependsOn fatJar

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-androidSdkHome=/home/yordanpetrov/dev/tools/android-sdk-linux
 androidSdkTarget=android-19
 androidSdkBuildToolsDir=build-tools/23.0.3
 bootClasspath = "${System.getenv('JAVA_HOME')}/jre/lib/rt.jar"


### PR DESCRIPTION
Missing file extension for Windows build.
Add '.bat' file extension on dx file ('task dex' in 'build.gradle' file)
fix #2 
